### PR TITLE
Change from requesting artifact metadata from TeamCity to using cached metadata

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -125,7 +125,7 @@ function download() {
         return;
     }
 
-    var remoteURL = "https://teamcity.labkey.org/guestAuth/app/rest/builds/status:SUCCESS,buildType:id:" + downloadTypeString + "/artifacts/children";
+    var remoteURL = "/releases/" + downloadTypeString + ".xml";
     //alert("Remote URL: " + remoteURL);
 
     var teamCityInfoString = "";


### PR DESCRIPTION
Change from requesting artifact metadata from TeamCity to using cached metadata that TeamCity uploads to SourceForge after every successful build. (TeamCity is just requesting the same `/artifacts/children` URL for each build type and uploading the XML to SourceForge.)

Access to teamcity.labkey.org (but not www.labkey.org) is blocked behind China's great firewall for reasons known only to the CPC. This should avoid that problem (until they block SourceForge again, at least).