### PR TITLE
Revert "Change from requesting artifact metadata from TeamCity to using cached metadata"

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -125,7 +125,7 @@ function download() {
         return;
     }
 
-    var remoteURL = "/releases/" + downloadTypeString + ".xml";
+    var remoteURL = "https://teamcity.labkey.org/guestAuth/app/rest/builds/status:SUCCESS,buildType:id:" + downloadTypeString + "/artifacts/children";
     //alert("Remote URL: " + remoteURL);
 
     var teamCityInfoString = "";


### PR DESCRIPTION
Reverts ProteoWizard/web#11

I think aggressive SourceForge caching is preventing the XML files from being properly updated. Until I can fix that, revert to old behavior of client querying TeamCity.