### PR TITLE
Revert 12 revert 11 cached artifact metadata

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -125,7 +125,7 @@ function download() {
         return;
     }
 
-    var remoteURL = "https://teamcity.labkey.org/guestAuth/app/rest/builds/status:SUCCESS,buildType:id:" + downloadTypeString + "/artifacts/children";
+    var remoteURL = "/releases/" + downloadTypeString + ".xml";
     //alert("Remote URL: " + remoteURL);
 
     var teamCityInfoString = "";


### PR DESCRIPTION
I added an .htaccess file to the releases directory to disable caching and it seems to work. Assuming caching is really properly disabled, then if the release XML files on SourceForge get out of sync now, it should be a problem on the TeamCity side with the XMLs not being updated correctly.